### PR TITLE
temporary for #10

### DIFF
--- a/_includes/footer.htm
+++ b/_includes/footer.htm
@@ -4,18 +4,19 @@
 </nav>
 <footer class="container12" style="border-top: 1px solid black;padding:10px 0">
 	<ul span=12 row>
+<!-- Given that the site is live, I recommend removing the links until they are go somewhere. If it was still in development, they are good placeholders. -->
 		<li span=3>
-			<ul>
-				<li><a href="/contact.html">Contact</a>
-			</ul>
+			<!-- <ul>
+				<li><a href="">Contact</a>
+			</ul> -->
 		<li span=3>
-			<ul>
+			<!-- <ul>
 				<li><a href="">Developers</a>
-			</ul>
+			</ul> -->
 		<li span=4>
-			<ul>
+			<!-- <ul>
 				<li><a href="">More</a>
-			</ul>
+			</ul> -->
 		<li span=2>
 			<a href="http://www.osgi.org"><img style="float:right;width:8em" src="/img/osgi-logo-256.png"></a>
 	</ul>


### PR DESCRIPTION
Given that the site is live, I recommend removing the links until they
are go somewhere. The site is cleaner and less confusing without the
dead end links.

Per issue #13, it would be better (IMHO) to be using Liquid comments
that do not appear in the rendered pages. I am using HTML comments to
be consistent with comments elsewhere.

Signed-off-by: Grant Pax <grant@fwep.twostewards.com>