### PR TITLE
_book/217-ds.md: target.foo -> foo.target

### DIFF
--- a/_book/217-ds.md
+++ b/_book/217-ds.md
@@ -220,7 +220,7 @@ This will create an instance of the Foo service with a service property ‘foo=b
 Obviously this is not symmetric. We need to know the name of the service property ahead of time in the Bar service. It is therefore possible to set the target field of the @Reference annotation with configuration admin:
 
 	service.pid		:	com.acme.Bar
-	target.foo		:	‘(foo=bar)’
+	foo.target		:	‘(foo=bar)’
 
 ## Component Factory
 


### PR DESCRIPTION
Peter quoted the relevant part from the spec :
"The name of a target property is the name of a reference appended with .target."