### PR TITLE
{{value}} stripped from markdown

### DIFF
--- a/_tutorial_rsa/260-gui.md
+++ b/_tutorial_rsa/260-gui.md
@@ -321,7 +321,7 @@ The controller initializes a `chat` object with a `users` list, a selected `user
 ## The Display (HTML)
 
 We're almost there. We now must replace the `static/osgi.enroute.examples.chat/main/htm/home.htm` file with the HTML definition of our user interface:
-
+{% raw %}
 	<section ng-cloak class="row">
 	  
 	  <div class="col-md-4 chat-user">
@@ -368,6 +368,7 @@ We're almost there. We now must replace the `static/osgi.enroute.examples.chat/m
 	      </form>
 	  </div>
 	</section>
+{% endraw %}
 
 ## The Styling (CSS)
 


### PR DESCRIPTION
Just did the Distributed tutorial, and noticed some text were missing, in the last part where there's some angular code in the HTML.

In particular, {{something}} seems to mean something to markdown.
We need to enclose it in {% raw %} ... {% endraw %}