### PR TITLE
Typo: UserApplication should be UpperApplication

### DIFF
--- a/_qs/410-exercise-service.md
+++ b/_qs/410-exercise-service.md
@@ -39,7 +39,7 @@ We then should change the `UpperImpl` class to implement the `Upper` interface f
 
 In general, a provider bundle should export the API it _provides_; in our case we provide the contract specified in the `com.acme.prime.upper.api` package. Exporting this package is a highly recommended best practice, it makes a lot of things work better later on. You can export this package by selecting the `bnd.bnd` file in the `com.acme.prime.upper.provider` project, and then the `Contents` tab. Notice the import: `com.acme.prime.upper.api`. Drag this import to the export list and save the file. The imports now disappears.
 
-### Change the User Application
+### Change the Upper Application
 
 We now need to change the `UpperApplication` class to use our new incredibly powerful service. Currently it has no dependencies so we should add the dependency on the Upper service. 
 

--- a/_qs/410-exercise-service.md
+++ b/_qs/410-exercise-service.md
@@ -41,11 +41,11 @@ In general, a provider bundle should export the API it _provides_; in our case w
 
 ### Change the User Application
 
-We now need to change the `UserApplication` class to use our new incredibly powerful service. Currently it has no dependencies so we should add the dependency on the Upper service. 
+We now need to change the `UpperApplication` class to use our new incredibly powerful service. Currently it has no dependencies so we should add the dependency on the Upper service. 
 
 The first thing we need to do is to make sure the Upper Application can see the API project. So click on the `bnd.bnd` file, select the `Build` tab, and add the API project, just like we did in the provider project.
 
-Then we change the `UserApplication` component class. We must add a setter method for the `Upper` service with a `@Reference` annotation to the end of the class (convention is to place references at the end):
+Then we change the `UpperApplication` component class. We must add a setter method for the `Upper` service with a `@Reference` annotation to the end of the class (convention is to place references at the end):
 
 	@Reference
 	Upper		upper;


### PR DESCRIPTION
I'm assuming that this was a typo - as there's no UserApplication and later the text continues to talk about the UpperApplication. Tiny glitch - I somewhat "autocorrected" it on first read, but figured that something was slightly irritating. Took me a bit to figure it out - that's how tiny it is