### PR TITLE
Typo in base tutorial

### DIFF
--- a/_tutorial_base/800-ci.md
+++ b/_tutorial_base/800-ci.md
@@ -51,7 +51,7 @@ For almost all features of bndtools there is a corresponding gradle task you can
 	BUILD SUCCESSFUL
 {: .shell }
 
-This task will store the output in `com.acme.prime.eval.appplication/generated/distributions/executable/com.acme.prime.eval.jar`.
+This task will store the output in `com.acme.prime.eval.application/generated/distributions/executable/com.acme.prime.eval.jar`.
 
 ## Putting it on Github
 


### PR DESCRIPTION
Was a bit to fast in previous fix, mistyped "application"