### PR TITLE
Principles link fix

### DIFF
--- a/_book/300-principles.html
+++ b/_book/300-principles.html
@@ -10,6 +10,6 @@
     </head>
     <body>
         <!-- Note: don't tell people to `click` the link, just tell them that it is a link. -->
-        If you are not redirected automatically, follow the <a href='/doc/300-principles.html'>link to example</a>
+        If you are not redirected automatically, follow the <a href='/doc/300-principles.html'>link to Principles section</a>
     </body>
 </html>

--- a/_book/300-principles.html
+++ b/_book/300-principles.html
@@ -2,14 +2,14 @@
 <html lang="en-US">
     <head>
         <meta charset="UTF-8">
-        <meta http-equiv="refresh" content="0;url=/doc/050-start.html">
+        <meta http-equiv="refresh" content="0;url=/doc/300-principles.html">
         <script type="text/javascript">
-            window.location.href = "/doc/050-start.html"
+            window.location.href = "/doc/300-principles.html"
         </script>
         <title>Page Redirection</title>
     </head>
     <body>
         <!-- Note: don't tell people to `click` the link, just tell them that it is a link. -->
-        If you are not redirected automatically, follow the <a href='/doc/050-start.html'>link to example</a>
+        If you are not redirected automatically, follow the <a href='/doc/300-principles.html'>link to example</a>
     </body>
 </html>


### PR DESCRIPTION
The "principles section" link at the bottom of page book/100-introduction seems to be broken. This'll fix it.