### PR TITLE
Changes for the first 6 steps in the tutorial

### DIFF
--- a/_tutorial_eval/050-start.md
+++ b/_tutorial_eval/050-start.md
@@ -18,7 +18,7 @@ aficionados.)
 What we will build is a similar application that is developed in the [Base Tutorial] but instead of Bndtools we use Maven. 
 
 This application is a trivial Web application. It provides a text input box and an `Eval` button. The
-box is send to the server for evaluation. There a service is used to evaluate the input. We'll
+text is sent to the server for evaluation. There a service is used to evaluate the input. We'll
 turn the application into an executable JAR that contains all its dependencies.
 
 The tutorial will only use plain Maven and vi. You can of course use your own favorite

--- a/_tutorial_eval/300-api.md
+++ b/_tutorial_eval/300-api.md
@@ -45,7 +45,6 @@ that POM.
 			<groupId>org.osgi</groupId>
 			<artifactId>osgi.enroute.examples.eval</artifactId>
 			<version>1.0.0-SNAPSHOT</version>
-			<relativePath>..</relativePath>
 		</parent>
 		
 We inherit the version and group Id from our parent POM so we only have to specify
@@ -228,8 +227,8 @@ Our `osgi.enroute.examples.eval/api` directory should look as follows:
 
 	bnd.bnd
 	pom.xml
-	src/main/java/package-info.java
-	src/main/java/Eval.java
+	src/main/java/osgi/enroute/examples/eval/api/package-info.java
+	src/main/java/osgi/enroute/examples/eval/api/Eval.java
 
 You might have a `target` directory, this is where maven stores temporary files. To update/create the
 target we run `mvn install` again.

--- a/_tutorial_eval/350-provider.md
+++ b/_tutorial_eval/350-provider.md
@@ -62,7 +62,6 @@ The parent and packaging is the same as for the API project:
 	  	<groupId>org.osgi</groupId>
 	  	<artifactId>osgi.enroute.examples.eval</artifactId>
 	  	<version>1.0.0-SNAPSHOT</version>
-		<relativePath>..</relativePath>
 	  </parent>
 	  
 	  <packaging>jar</packaging>
@@ -72,9 +71,10 @@ project name defines its *type*; this is supported by OSGi enRoute templates. A 
 project must therefore have a name that ends in `.provider`. We also like to start 
 the project name with the workspace, the service API name and an indication of what 
 kind of implementation this is. Well, this is going to be an awful simple implementation, 
-so the name should be: `osgi.enroute.examples.eval.provider`. So in the POM we should have:
+so the name should be: `osgi.enroute.examples.eval.simple.provider`. So in the POM we should have:
 
 	  <artifactId>osgi.enroute.examples.eval.simple.provider</artifactId>
+	  <description>Eval Provider</description>
 
 We inherit the OSGi enRoute base API (a collection of standardized and specialized service contracts to 
 make it easy for web apps) but in this case we need the API project as dependency
@@ -190,11 +190,27 @@ There are OSGi experts who do not completely agree though.
 
 ## Build
 
-We now have enough project information to build the bundle. It is about time now to take a look 
-at how our module (bundle) really looks like. So let's build it.
+In Maven-terms we've now defined a multi-module project, currently containing two modules : api and simple.provider.
+The modules should be defined in an aggregator pom, and often this is done in the parent pom.
+We should add a <modules> section in the pom.xml in the parent folder
 
-	simple.provider $ mvn clean install
+	simple.provider $ cd ..
+	osgi.enroute.examples.eval $ vi pom.xml
+	// fill in from next section, right before the <properties> section
+{: .shell }
+
+	  <modules>
+	  	<module>api</module>
+	  	<module>simple.provider</module>
+	  </modules>
+
+We now have enough project information to build the bundle. As we've changed the parent pom, it's best to do a clean build from there.
+And then we can take a look at how our module (bundle) really looks like.
+Make sure you're in the top directory!
+
+	osgi.enroute.examples.eval $ mvn clean install
 	...
+	osgi.enroute.examples.eval $ cd simple.provider
 	simple.provider $ bnd print target/osgi.enroute.examples.eval.simple.provider-1.0.0-SNAPSHOT.jar
 	[MANIFEST osgi.enroute.examples.eval.provider-1.0.0-SNAPSHOT]
 	Bnd-LastModified                         1474989660493                           
@@ -202,24 +218,26 @@ at how our module (bundle) really looks like. So let's build it.
 	Built-By                                 aqute                                   
 	Bundle-Description                       Provides a simple implementation for an eval parser
 	Bundle-ManifestVersion                   2                                       
-	Bundle-Name                              osgi.enroute.examples.eval.provider      
-	Bundle-SymbolicName                      osgi.enroute.examples.eval.provider      
+	Bundle-Name                              osgi.enroute.examples.eval.simple.provider      
+	Bundle-SymbolicName                      osgi.enroute.examples.eval.simple.provider      
 	Bundle-Version                           1.0.0.201609271521                      
 	Created-By                               1.8.0_25 (Oracle Corporation)           
 	Export-Package                           osgi.enroute.examples.eval.api;version="1.0.0"
-	Import-Package                           osgi.enroute.examples.eval.api;version="[1.0,2)"
+	Import-Package                           osgi.enroute.examples.eval.api;version="[1.0,1.1)"
 	Manifest-Version                         1.0                                     
 	Private-Package                          osgi.enroute.examples.eval.provider      
 	Provide-Capability                       osgi.service;objectClass:List<String>="osgi.enroute.examples.eval.api.Eval"
 	Require-Capability                       osgi.ee;filter:="(&(osgi.ee=JavaSE)(version=1.8))"
+	Require-Capability                       osgi.extender;filter:="(&(osgi.extender=osgi.component)(version>=1.3.0)(!(version>=2.0.0)))",osgi.service;filter:="(objectClass=org.osgi.service.log.LogService)";effective:=active,osgi.ee;filter:="(&(osgi.ee=JavaSE)(version=1.8))"
 	Service-Component                        OSGI-INF/osgi.enroute.examples.eval.provider.xml
 	Tool                                     Bnd-3.3.0.201609221906                  
 
 	[IMPEXP]
 	Import-Package
-	  osgi.enroute.examples.eval.api          {version=[1.0,2)}
+	  org.osgi.service.log                    {version=[1.3,2)}
+	  osgi.enroute.examples.eval.api          {version=[1.0,1.1)}
 	Export-Package
-	  osgi.enroute.examples.eval.api          {version=1.0.0, imported-as=[1.0,2)}
+	  osgi.enroute.examples.eval.api          {version=1.0.0, imported-as=[1.0,1.1)}
 {: .shell }
 
 From this we can see the following layout of our provider bundle.

--- a/_tutorial_eval/380-run.md
+++ b/_tutorial_eval/380-run.md
@@ -46,7 +46,6 @@ In the `osgi.enroute.examples.eval` directory we create the `pom.xml` file in a 
 			<groupId>org.osgi</groupId>
 			<artifactId>osgi.enroute.examples.eval</artifactId>
 			<version>1.0.0-SNAPSHOT</version>
-			<relativePath>..</relativePath>
 		</parent>
 	
 		<artifactId>osgi.enroute.examples.eval.bndrun</artifactId>
@@ -116,6 +115,8 @@ the interoperability of OSGi.
 
 		</dependencies>
 	</project>
+
+We must also add bndrun as module in the parent pom.xml, e.g. after the existing api and simple.provider modules.
 
 ## The bndrun file
 
@@ -210,7 +211,7 @@ fail but it will give the list of calculated bundles:
 		org.apache.felix.scr; version='[2.0.2,2.0.3)',\
 		org.eclipse.equinox.metatype; version='[1.4.100,1.4.101)',\
 		org.osgi.service.metatype; version='[1.3.0,1.3.1)',\
-		osgi.enroute.examples.eval.provider; version='[1.0.0,1.0.1)'
+		osgi.enroute.examples.eval.simple.provider; version='[1.0.0,1.0.1)'
 	
 	[INFO] ------------------------------------------------------------------------
 	[INFO] BUILD FAILURE
@@ -279,9 +280,8 @@ If we build and run the application, we see the following:
 	# registered launcher with arguments for syncing
 	# will wait for a registered Runnable
 	
-The output quite extensive. If you have problems during the launch is a great help
-when you're having problems. Including this information with a bug report is
-highly appreciated.
+The output is quite extensive. If you have problems during the launch it is a great help 
+and including this information with a bug report is highly appreciated.
 
 ## The Gogo Shell
 

--- a/_tutorial_eval/400-command.md
+++ b/_tutorial_eval/400-command.md
@@ -48,7 +48,6 @@ And the content:
 			<groupId>org.osgi</groupId>
 			<artifactId>osgi.enroute.examples.eval</artifactId>
 			<version>1.0.0-SNAPSHOT</version>
-			<relativePath>..</relativePath>
 		</parent>
 		<packaging>jar</packaging>
 	
@@ -62,6 +61,8 @@ And the content:
 			</dependency>
 		</dependencies>
 	</project>
+
+We must also add command as module in the parent pom.xml, as we've done for the modules of the previous steps in this tutorial.
 
 ## The Command
 
@@ -216,7 +217,6 @@ JAR.
 	
 	              
 	G! eval 3 + 4
-	eval 3 + 4
 	7.0
 	G! 
 {: .shell }


### PR DESCRIPTION
These are changes in the tutorial texts for steps 1-6.

Nothing fundamental, the tutorial is already very easy to follow and very complete.

Some typo's, removing relative path to parent pom (as it's the default anyway) and the main thing : a short mention about multi-module maven project configuration in the parent pom.

The rest should follow later today or tomorrow.

erwin