### PR TITLE
Fixes for Base and Maven tutorials

### DIFF
--- a/_tutorial_base/200-workspace.md
+++ b/_tutorial_base/200-workspace.md
@@ -14,19 +14,19 @@ Optionally, you can learn how Eclipse, Git, enRoute, and bnd workspaces relate t
 
 Before you start this section, make sure you've checked the [prerequisites](100-prerequisites.html) for OSGi enRoute on your platform. 
 
-In the next section you learn how to setup a workspace. For this tutorial you must ensure you have a new workspace. If you've done the quickstart
-tutorial you might already have workspace. Delete it or use another name for this tutorial to not get confused.
+In the next section you learn how to set up a workspace. For this tutorial you must ensure you have a new workspace. If you've done the quickstart
+tutorial you might already have a workspace. Delete it or use one with another name for this tutorial to not get confused.
 
 {% include workspace.md %}
 
 ## How Does it Work?
 
-It helps to understand how the workspace are layed out. An Eclipse workspace is a directory where Eclipse stores its metadata, e.g. the plugins persistent storage or the history. Though it can be used to also store the actual projects, it is in general not a good idea, especially if you use a source control system. EGit can actually become quite slow when you include the Git workspace.
+It helps to understand how the workspace is layed out. An Eclipse workspace is a directory where Eclipse stores its metadata, e.g. the plugins persistent storage or the history. Though it can be used to also store the actual projects, it is in general not a good idea, especially if you use a source control system. EGit can actually become quite slow when you include the Git workspace.
 
-Therefore, the best way to work with projects in Eclipse is to not store them in the Eclipse workspace folder but import them from another directory.
+Therefore, the best way to work with projects in Eclipse is not to store them in the Eclipse workspace folder but to import them from another directory.
 
 For bnd, a workspace is a directory with a `cnf` folder and a number of projects. This is a flat space; hated by many but it works quite well because it is very simple and hard to get wrong. Don't count on it changing so do not try to work around it, you'll regret it. The `cnf` folder contains a `build.bnd` file and a `ext` directory which together define the workspace properties.
 
 A bnd workspace is like a module; it imports bundles (and JARs) from a repository and it exports bundles to the same or another repository. On the inside we have projects that are private to the workspace. The projects should be cohesive so that they can share information via the `cnf` project.
 
-The Git workspace is a directory that has a `.git` sub directory. When used with bnd, the Git workspace and the bnd workspace overlap. That is, the bnd workspace is one Git workspace, projects do not have their own repositories. 
+The Git workspace is a directory that has a `.git` sub directory. When used with bnd, the Git workspace and the bnd workspace overlap. That is, the bnd workspace is a single Git workspace. Projects do not have their own repositories. 

--- a/_tutorial_base/300-api.md
+++ b/_tutorial_base/300-api.md
@@ -42,7 +42,7 @@ This is not the only name enRoute recognizes. You can actually use the following
 A bug in the templates requires the name to consist of at least 3 segments like: `a.b.api`.
 {: .bug }
 
-So let's create the `com.acme.prime.eval.api` project. Start with `New/Bndtools OSGi Project`. 
+So let's create the `com.acme.prime.eval.api` project. Start with `New/Bndtools/Bnd OSGi Project`. 
 
 This will open a dialog page where we are going to select a _template_. For the template, select the OSGi enRoute templates. The OSGi enRoute template will pick an appropriate layout for your project depending on the last segment or extension of your project name.
  
@@ -54,7 +54,7 @@ Add the name of the project (`com.acme.prime.eval.api`).
 ![Create API Project](/img/tutorial_base/project-create-1.png)
 {: style='max-width:400px'}
 
-Then you can just click through `Next`, we do not have to set anything on this page, just continue and click `Finish`. This creates a small project with all the options set to treat it as an API project. The templates already created the `Eval` interface for you in the right package, just fill in the source code we discussed earlier.
+Then you can just click through `Next`. We do not have to set anything on this page, just continue and click `Finish`. This creates a small project with all the options set to treat it as an API project. The templates already created the `Eval` interface for you in the right package, just fill in the source code we discussed earlier.
 
 ![Add the Interface](/img/tutorial_base/project-create-2.png)
 
@@ -92,7 +92,7 @@ Obviously it is a nightmare to ensure that the proper version ranges are used. W
 	
 The bnd tool will now automatically ensure that any _implementers_ of this interface use semantic versioning to import the package with a minor range, for example `[1.0,1.1)`.
 
-Interfaces that are implemented by the consumer of your API (usually listener like interfaces) can be annotated with the @ConsumerType annotation. However, this is the default.
+Interfaces that are implemented by the consumer of your API (usually listener-like interfaces) can be annotated with the @ConsumerType annotation. However, this is the default.
  
 If you find this hard to grasp then you're not alone. This is a very complex area. We will get back to this later.
 

--- a/_tutorial_base/320-provider.md
+++ b/_tutorial_base/320-provider.md
@@ -16,7 +16,7 @@ In the previous section we created an API for an expression evaluator. We now ne
 
 	com.acme.prime.eval.provider
 
-So let's create a new project with this name. `New/Bndtools OSGi Project`. Enter the new (`com.acme.prime.eval.provider`), select the OSGi enRoute templates, and follow the defaults.
+So let's create a new project with this name. In Eclipse, choose `New/Bndtools/Bnd OSGi Project`. Enter the new name (`com.acme.prime.eval.provider`), select the OSGi enRoute templates, and follow the defaults.
 
 ![Provider Project](/img/tutorial_base/provider-create-0.png)
 
@@ -35,7 +35,7 @@ The dependencies of bnd are defined in the `bnd.bnd` file. We can control the bu
 
 ![Build Tab](/img/tutorial_base/provider-create-1.png)
 
-This tab does not only show you the bnd errors, it also shows you the current build path (OSGi enRoute API, JUnit, etc). To add the API project, click on the green plus ('+') just above the list. This pops up a list of all the *repositories*. As you can see, the top repository is the workspace and contains our API project. 
+This tab not only shows you the bnd errors, it also shows you the current build path (OSGi enRoute API, JUnit, etc). To add the API project, click on the green plus ('+') just above the list. This pops up a list of all the *repositories*. As you can see, the top repository is the workspace and contains our API project. 
 
 ![Adding to the Build Path](/img/tutorial_base/provider-create-2.png)
 
@@ -73,7 +73,7 @@ Ok, ok, simple might still give it too much credit but we're not here to learn p
 
 ## Imports
 
-It is about time now to take a look at how our module (bundle) really looks like. Let's double click on `bnd.bnd` and select the `Contents` tab. This tab shows us how the bundle is layed out:
+It is about time now to take a look at what our module (bundle) really looks like. Let's double click on `bnd.bnd` and select the `Contents` tab. This tab shows us how the bundle is layed out:
 
 * Private packages – Packages that are only available inside the bundle. Another bundle could have the same name for the package but different contents.
 * Exported packages – Packages that we provide to other bundles and which we are supposed to maintain over time.
@@ -103,7 +103,7 @@ Anyway, our bundle now looks different:
 
 ## How Does it Work?
 
-The concepts of consumers and providers can be confusing, mostly because it is often confused with implementers of an interface and the clients of an interface. However, providers of a service API can both implement and/or be a client of interfaces in the service package. A provider is responsible for providing the value of the contract, and a consumer receives the value of the contract. The reason we need to distinguish between these two roles is that they have far ranging consequences for how you package and version bundles.
+The concepts of consumers and providers can be confusing, mostly because they are often confused with implementers of an interface and clients of an interface. However, providers of a service API can both implement and/or be a client of interfaces in the service package. A provider is responsible for providing the value of the contract and a consumer receives the value of the contract. The reason we need to distinguish between these two roles is that they have far ranging consequences for how you package and version bundles.
 
 Lets say you buy a house from me. In this scenario you are consumer of the contract and I am the provider of the contract. These roles are, surprisingly, not symmetrical. For example, if the seller adds an extra room after the contract was signed then the buyer will not object (ok, in general, you get my point). However, if the seller removes a room the buyer is going to be upset. A consumer can expect backward compatibility but a provider is closely bound to the contract. Virtually any change in the service contract will require a provider to be updated to provide the new functions. 
 

--- a/_tutorial_base/340-junit.md
+++ b/_tutorial_base/340-junit.md
@@ -29,7 +29,7 @@ So let's evaluate a simple expression:
 		}
 	}
 
-Now, when I learned flying in a retractable gear plane my teacher told me that there are two kind of retractable gear pilots. The first category is the pilots that have landed the plane with gear up and the second category is for the pilots that have not yet landed their planes with gear up. Something like this is going to happen to you when testing in bndtools. In this case you must use the standard Eclipse JUnit test after selecting the test class or method: `@/Run As/JUnit Test`. Undoubtedly, there will be many times when you select the `Bnd OSGi Test Launcher (JUnit)` which we will discuss later. So select the `EvalImplTest` class and do `@/Run As/JUnit Test`.
+Now, when I learned flying in a retractable gear plane, my teacher told me that there are two kind of retractable gear pilots. The first category is the pilots that have landed the plane with gear up and the second category is for the pilots that have not yet landed their planes with gear up. Something like this is going to happen to you when testing in bndtools. In this case you must use the standard Eclipse JUnit test after selecting the test class or method: `@/Run As/JUnit Test`. Undoubtedly, there will be many times when you select the `Bnd OSGi Test Launcher (JUnit)` which we will discuss later. So select the `EvalImplTest` class and do `@/Run As/JUnit Test`.
 
 ![JUnit](/img/tutorial_base/junit-0.png)
 

--- a/_tutorial_base/400-run.md
+++ b/_tutorial_base/400-run.md
@@ -26,7 +26,9 @@ The way we usually do this in OSGi is by creating a command in the [Apache Felix
 
 These properties register the `test:eval` command with Gogo. The scope (the `test` part) is always required to disambiguate commands. (In this case it is actually really required since Gogo already has an eval command, ok, bad planning).
 
-Note that if you copy paste the "property" definition above in your code, eclipse will complain that it cannot find the "Debug" class. Just go to next to it and press Ctrl+Space to import the necessary class automatically.{: .note }
+Note that if you copy paste the "property" definition above in your code, eclipse will complain that it cannot find the "Debug" class. Just go to next to it and press Ctrl+Space to import the necessary class automatically.
+{: .note }
+
 
 ## Runtime Environment
 
@@ -89,7 +91,7 @@ Sometimes, you know, life is just good ...
 
 ## Updating
 
-Adding, subtracting, gets a bit boring after a while, didn't the bible tell us to multiply? So why not be nice and add multiplication and division. Open the provider project and change the implementation of eval as follows:
+Adding, subtracting, gets a bit boring after a while. Didn't the Bible tell us to multiply? So why not be nice and add multiplication and division. Open the provider project and change the implementation of eval as follows:
 
 	Pattern EXPR = Pattern
 			.compile("\\s*(?<left>\\d+)\\s*(?<op>\\+|-|\\*|/)\\s*(?<right>\\d+)\\s*");
@@ -107,7 +109,7 @@ Adding, subtracting, gets a bit boring after a while, didn't the bible tell us t
 			return left / right;
 		}
 
-Just add the new code and save the `EvalImpl` class, then go to the Gogo shell. Hmm, you did not really have to stop the framework, in the OSGi world we are dynamic. So if you out of bad habit killed the running process you should first restart the framework. Click on the `bnd.bnd` file, select the `Run` tab and click the `Debug OSGi` button. If you don't understand what I am talking about, well, your framework should still be humming along, having just been updated. So assuming we're all in the Gogo shell now:
+Just add the new code and save the `EvalImpl` class, then go to the Gogo shell. Hmm, you did not really have to stop the framework, in the OSGi world we are dynamic. So if you out of bad habit killed the running process, you should first restart the framework. Click on the `bnd.bnd` file, select the `Run` tab and click the `Debug OSGi` button. If you don't understand what I am talking about, well, your framework should still be humming along, having just been updated. So assuming we're all in the Gogo shell now:
 
 	g! test:eval 6*7
 	42.0

--- a/_tutorial_base/450-debug.md
+++ b/_tutorial_base/450-debug.md
@@ -29,7 +29,7 @@ Duh, that is only in stuffy classic environments! In an OSGi environment we do n
 
 ## What's Inside?
 
-Of course OSGi enRoute will never let you down, you're life will be tranquil, and you can spend lots of time on the beach. Ehh, well, we will try but computer intelligence is generally not that advanced yet and in the mean time you will have to do some debugging and diagnosing to make actual applications work. Sad, but true.
+Of course OSGi enRoute will never let you down, your life will be tranquil, and you can spend lots of time on the beach. Ehh, well, we will try but computer intelligence is generally not that advanced yet and in the mean time you will have to do some debugging and diagnosing to make actual applications work. Sad, but true.
 
 One of the great tools to debug OSGi applications is the Apache Felix Web Console. The Web Console provides insight in everything you wanted to know about OSGi, and actually a lot more.  Especially XRay, a web console plugin, is very useful for beginners because it visualizes the services layer very well. In Xray, each service type is represented by an icon and wires run back and forth to the bundles registering and getting them (and even just listening).
 

--- a/_tutorial_base/700-deploy.md
+++ b/_tutorial_base/700-deploy.md
@@ -18,9 +18,9 @@ The beauty of an executable JAR is that it can be started anywhere there is a ja
 
 ## Creating an Application
 
-The first thing we need to do is create a `bndrun` file. A `bndrun` file is a separate file for the `bnd.bnd` `Run` tab. It allows us to specify a runtime for our framework. 
+The first thing we need to do is create a `bndrun` file. Don't confuse a `bndrun` file with the `Run` tab of the `bnd.bnd` file. These are two distinct files. A `bndrun` file allows us to specify a runtime for our framework. 
 
-So do a `New/Bndtools OSGi Project` and use `com.acme.prime.eval.application` as the project name. The `.application` extension for this project creates an *application* project. Don't forget to use the OSGi enRoute templates!
+So do a `New/Bndtools/Bnd OSGi Project` and use `com.acme.prime.eval.application` as the project name. The `.application` extension for this project creates an *application* project. Don't forget to use the OSGi enRoute template!
 
 An application project should contain no code (or very little) but acts as a spear point. It contains the requirements that will drive the final application.
 
@@ -51,7 +51,7 @@ By default, an application only contains a Gogo shell command, in this case in t
 
 This code registers a dummy service that now provides the `eval:eval` command to Gogo shell (notice the imaginative difference between the `test:eval` command we created in the provider.
 
-Just like the test project, we need to add a dependency on the API project. As usual, go to the `Build` tab and add the `com.acme.prime.eval.api` project.
+Just like the test project, we need to add a dependency on the API project. As usual, go to the `Build` tab of the `bnd.bnd` file and add the `com.acme.prime.eval.api` project.
 
 ## Defining the Application
 

--- a/_tutorial_eval/360-provider-junit.md
+++ b/_tutorial_eval/360-provider-junit.md
@@ -42,14 +42,14 @@ In Maven, we have to write our test cases in `src/test/java`.
 {: .shell }
 
 	package osgi.enroute.examples.eval.simple.provider;
+
 	import junit.framework.TestCase;
 	import osgi.enroute.examples.eval.provider.EvalImpl;
 	
 	public class EvalImplTest extends TestCase {
-	
 		public void testSimple() throws Exception {
 			EvalImpl t = new EvalImpl();
-			assertEquals( 3.0,  t.eval("1 + 2"));
+			assertEquals(3.0, t.eval("1 + 2"));
 		}
 	}
 

--- a/_tutorial_eval/380-run.md
+++ b/_tutorial_eval/380-run.md
@@ -3,7 +3,7 @@ title: OSGi Runtime
 layout: tutorial
 lprev: 360-provider-junit
 lnext: 400-command
-summary: How to create an OSGi Runtim
+summary: How to create an OSGi Runtime
 ---
 
 ## What You Will Learn in This Section
@@ -246,7 +246,7 @@ We can now run the application as follows:
 	bndrun $ java -jar osgi.enroute.examples.eval.jar
 	
 
-The output is embarrassing little ...
+The output is a little embarrassing ...
 
 Though rather disappointing, it does make sense since we've not created any bundle that
 does something that is visual to us. So the lack of output is understandable.

--- a/_tutorial_eval/400-command.md
+++ b/_tutorial_eval/400-command.md
@@ -25,7 +25,7 @@ Make sure you are in the top directory:
 
 ## Creating a POM 
 
-We need to create a directory called `command` in the `osgi.enroute.examples.eval' 
+We need to create a directory called `command` in the `osgi.enroute.examples.eval` 
 directory. In this directory we need to create a `pom.xml` file. The POM is quite standard now:
 
 

--- a/_tutorial_eval/430-dependencies.md
+++ b/_tutorial_eval/430-dependencies.md
@@ -3,7 +3,7 @@ title: Dependencies
 layout: tutorial
 lprev: 400-command
 lnext: 450-web
-summary: Use a standard parsers instead of our simplistic parser
+summary: Use a standard parser instead of our simplistic parser
 ---
 
 ## What You Will Learn in this Section
@@ -164,10 +164,7 @@ We now build the bundle:
 	  osgi.enroute.examples.eval.api         {version=1.0.0, imported-as=[1.0,1.1)}
 {: .shell }
 
-The Private-Package header added by bnd clearly shows that we've added the `parsii` packages that
-it found in the bundle. We specified a wild card in the bnd.bnd file for Private-Package
-but in the manifest we can clearly see that there is a ` parsii.tokenizer` and `parsii.eval` 
-package on the classpath.
+The Private-Package header added by bnd clearly shows that we've added the `parsii` packages that it found in the bundle. We specified a wild card in the `bnd.bnd` file for Private-Package but in the manifest we can clearly see that there are `parsii.tokenizer` and `parsii.eval` packages on the classpath.
 
 ## Running It
 
@@ -188,9 +185,9 @@ it can be used by the resolver. The dependencies should therefore look like:
                         <version>1.0.0-SNAPSHOT</version>
                 </dependency>
                 <dependency>
-                        <groupId>org.osgi</groupId>
-                        <artifactId>osgi.enroute.examples.eval.simple.provider</artifactId>
-                        <version>1.0.0-SNAPSHOT</version>
+                        <groupId>org.apache.felix</groupId>
+                        <artifactId>org.apache.felix.gogo.shell</artifactId>
+                        <version>1.0.0</version>
                 </dependency>
                 <dependency>
                         <groupId>org.osgi</groupId>
@@ -200,7 +197,7 @@ it can be used by the resolver. The dependencies should therefore look like:
                 <dependency>
                         <groupId>org.osgi</groupId>
                         <artifactId>osgi.enroute.pom.distro</artifactId>
-                        <version>2.0.0-SNAPSHOT</version>
+                        <version>2.0.0</version>
                 </dependency>
         </dependencies>
   

--- a/_tutorial_eval/450-web.md
+++ b/_tutorial_eval/450-web.md
@@ -15,11 +15,7 @@ web.
 We will create a small GUI in HTML 5 and Javascript based on Angular that uses
 the OSGi enRoute simple REST facility to call the evaluator service.
 
-For many Java developers Javascript, CSS, and HTML 5 are foreign and scary. However, this
-example requires very little of these resources and it is hard to admit that it
-is cool to write something you can show your girl/boy friend without getting
-blank stares? If you're absolutely not  interested in web applications then you can 
-skip this section.
+For many Java developers, Javascript, CSS, and HTML 5 are foreign and scary. However, this example requires very little knowledge of these resources. And won't you admit that it's cool to write something you can show your girl/boy friend without getting blank stares? If you're absolutely not interested in web applications then you can skip this section.
 
 ![API Diagram](img/application-diagram.png)
 
@@ -488,8 +484,13 @@ The dependencies section should look like:
 	    <dependency>
 	            <groupId>org.osgi</groupId>
 	            <artifactId>osgi.enroute.pom.distro</artifactId>
-	            <version>2.0.0-SNAPSHOT</version>
+	            <version>2.0.0</version>
 	    </dependency>
+		<dependency>
+		    <groupId>org.apache.felix</groupId>
+		    <artifactId>org.apache.felix.gogo.shell</artifactId>
+		    <version>1.0.0</version>
+		</dependency>
 	</dependencies>
 
 Then add the new `-runrequires` for the application:


### PR DESCRIPTION
Lots of grammar + punctuation fixes but also a few more significant fixes involving instructions and dependency specifications.