### PR TITLE
dtos.md typo fix

### DIFF
--- a/_appnotes/dtos.md
+++ b/_appnotes/dtos.md
@@ -187,26 +187,26 @@ For example, the OSGi enRoute REST service was designed with DTOs in mind. This 
     @Component
     public class MyManager implements REST {
         BundleContext context;
-        
+    
         @Activate
         void activate(BundleContext context) {
-           this.context = context;
+            this.context = context;
         }
-
+    
         public List<BundleDTO> getBundle() {
-		  return Stream.of(context.getBundles())
-		          .map( this::toDTO )
-		          .collect(Collectors.toList());        
-		}
-        
-        public BundleDTO getBundle(long id) {
-        	return getBundle(context.getBundle(id));
+            return Stream.of(context.getBundles())
+                   .map( this::toDTO )
+                   .collect(Collectors.toList());
         }
-	    
-	    BundleDTO toDTO( Bundle b) {
-	        return b.adapt( BundleDTO.class );
-	    }
-	}           
+    
+        public BundleDTO getBundle(long id) {
+            return getBundle(context.getBundle(id));
+        }
+    
+        BundleDTO toDTO( Bundle b) {
+            return b.adapt( BundleDTO.class );
+        }
+    }
 
 ## DTOs Service
 

--- a/_appnotes/dtos.md
+++ b/_appnotes/dtos.md
@@ -200,7 +200,7 @@ For example, the OSGi enRoute REST service was designed with DTOs in mind. This 
         }
     
         public BundleDTO getBundle(long id) {
-            return getBundle(context.getBundle(id));
+            return toDTO(context.getBundle(id));
         }
     
         BundleDTO toDTO( Bundle b) {


### PR DESCRIPTION
I believe the code example in `_appnotes/dtos.md` was calling a wrong method.  I only checked by eye, but I'm pretty sure it wouldn't even compile.

I also fixed mixed tabs/spaces and inconsistent indentation in that same code example.