### PR TITLE
Fixed broken links

### DIFF
--- a/_FAQ/300-declarative-services.md
+++ b/_FAQ/300-declarative-services.md
@@ -11,7 +11,7 @@ sponsor: OSGi™ Alliance
 
 Increasingly Declarative Services (DS) is the backbone of OSGi. While other Dependency Injection (DI) frameworks can be used with OSGi, the OSGi Alliance strongly recommend DS.
 
-All of the enRoute [examples](../examples) are DS based, and walk you from the simplest of DS components [quickstart](../examples/010-examples.html#the-ds-component) through DS range of capabilities.
+All of the enRoute examples are DS based and walk you from the simplest of DS components [quickstart](../examples/010-examples.html#the-ds-component) through a range of DS capabilities.
 
 
 ## Background

--- a/_about/115-bnd-plugins.md
+++ b/_about/115-bnd-plugins.md
@@ -19,7 +19,7 @@ Note that the `maven-jar-plugin` must be configured to accept this externally ge
 
 ### enRoute customisations
 
-OSGi enRoute further configures the `bnd-maven-plugin` to give a more friendly symbolic name for projects that use short artifact ids, to include sources in the generated bundle, and to use [OSGi Contracts (_Requirements_ & _Capabilities_](/faq/200-resolving.html) when they are available
+OSGi enRoute further configures the `bnd-maven-plugin` to give a more friendly symbolic name for projects that use short artifact ids, to include sources in the generated bundle, and to use [OSGi Contracts (_Requirements_ & _Capabilities_)](../FAQ/200-resolving.html) when they are available
 
 ## The bnd-export-maven-plugin
 
@@ -32,10 +32,10 @@ The indexes used in OSGi enRoute are typically for intermediate or local usage, 
 
 ## The bnd-resolver-maven-plugin
 
-The bnd-resolver-maven-plugin is not normally part of the main build, but it can be used from the command line to [resolve](/faq/200-resolving.html) an application or integration testing `bndrun`. This resolve operation takes a set of run requirements and uses an OSGi repository index to find the complete set of bundles that need to b deployed to satisfy the run requirements.
+The bnd-resolver-maven-plugin is not normally part of the main build, but it can be used from the command line to [resolve](../FAQ/200-resolving.html) an application or integration testing `bndrun`. This resolve operation takes a set of run requirements and uses an OSGi repository index to find the complete set of bundles that need to b deployed to satisfy the run requirements.
 
 ## The bnd-baseline-maven-plugin
-The bnd-baseline-maven-plugin is used to validate the [semantic versioning](/FAQ/210-semantic_versioning.md) of a bundle’s exported API by comparing it against the last released version. This plugin will fail the build if the API version has not been increased when a change has been made, or if the version increase is insufficient to communicate the semantics of the change.
+The bnd-baseline-maven-plugin is used to validate the [semantic versioning](../FAQ/210-semantic_versioning.md) of a bundle’s exported API by comparing it against the last released version. This plugin will fail the build if the API version has not been increased when a change has been made, or if the version increase is insufficient to communicate the semantics of the change.
 
 ## The bnd-testing-maven-plugin
 

--- a/_examples/010-examples.md
+++ b/_examples/010-examples.md
@@ -62,7 +62,7 @@ The DS component contains a number of important annotations.
   </div>
 </div>
 
-* **@Component** - This annotation indicates that `Upper` is a [Declarative Services](../faq/300-declarative-services) component. The `service` attribute means that even though `Upper` does not directly implement any interfaces it will still be registered as a service. The `@Component` annotation also acts as a runtime _Requirement_; prompting the host OSGi framework to automatically load a Declarative Services implementation.
+* **@Component** - This annotation indicates that `Upper` is a [Declarative Services](../FAQ/300-declarative-services) component. The `service` attribute means that even though `Upper` does not directly implement any interfaces it will still be registered as a service. The `@Component` annotation also acts as a runtime _Requirement_; prompting the host OSGi framework to automatically load a Declarative Services implementation.
 
 * **@JaxrsResource** - This annotation marks the `Upper` service as a JAX-RS resource type that should be processed by the [JAX-RS whiteboard](../FAQ/400-patterns.html#whiteboard-pattern). It also acts as a runtime _Requirement_; prompting the host OSGi framework to automatically load a JAX-RS Whiteboard implementation.
 

--- a/_examples/020-examples-microservice.md
+++ b/_examples/020-examples-microservice.md
@@ -129,7 +129,7 @@ The DS REST component contains a number of important annotations.
   </div>
 </div>
 
-* **@Component** - This annotation indicates that `RestComponentImpl` is a [Declarative Services](../faq/300-declarative-services) component. The `service` attribute means that even though `RestComponentImpl` does not directly implement any interfaces it will still be registered as a service. The `@Component` annotation also acts as a runtime _Requirement_; prompting the host OSGi framework to automatically load a Declarative Services implementation.
+* **@Component** - This annotation indicates that `RestComponentImpl` is a [Declarative Services](../FAQ/300-declarative-services) component. The `service` attribute means that even though `RestComponentImpl` does not directly implement any interfaces it will still be registered as a service. The `@Component` annotation also acts as a runtime _Requirement_; prompting the host OSGi framework to automatically load a Declarative Services implementation.
 
 * **@JaxrsResource** - This annotation marks the `RestComponentImpl` service as a JAX-RS resource type that should be processed by the [JAX-RS whiteboard](../FAQ/400-patterns.html#whiteboard-pattern). It also acts as a runtime _Requirement_; prompting the host OSGi framework to automatically load a JAX-RS Whiteboard implementation.
 


### PR DESCRIPTION
Removed unnecessary link to examples from 300-declarative services.
Fixed broken links caused by case sensitive & not using relative path.

Signed-off-by: Richard Nicholson <richard.nicholson@paremus.com>

