### PR TITLE
Update prerequisites to avoid java 9 and to install bndtools from eclipse market place

### DIFF
--- a/_tutorial/015-Prerequisite.md
+++ b/_tutorial/015-Prerequisite.md
@@ -14,7 +14,7 @@ Before you start any of the tutorials you must prepare your environment so that 
 
 We need to run the following tools on your computer - without them you won't get very far at all.
 
-* [Java][java8], probably already got it? If not, this is a good time to get started! enRoute projects target Java 8 by default, so make sure your Java is at least that version.
+* [Java][java8], probably already got it? If not, this is a good time to get started! enRoute projects target Java 8. The enRoute projects are affected by some breaking changes in Java 9, so for now use Java 8 only.
 * [Maven][Maven], a popular build tool for Java applications with an enormous repository behind it. Make sure that you're on at least 3.3.9
 
 ### Project Setup for SNAPSHOT Archetypes

--- a/_tutorial/015-Prerequisite.md
+++ b/_tutorial/015-Prerequisite.md
@@ -75,7 +75,9 @@ These tools aren't strictly required but we think that they'll improve your expe
 
 ### Installing Bndtools
 
-You can't install Bndtools 4.0.0 from the Eclipse market place yet as it hasn't been formally released, but you can install the Bndtools development snapshot directly from an update site using the instructions at:
+You can install Bndtools 4.0.0.REL or higher directly from the Eclipse market place.
+
+Alternatively you can install the Bndtools development snapshot directly from an update site using the instructions at:
 
         http://bndtools.org/installation.html#nonstandard_versions
 


### PR DESCRIPTION
This is to avoid these issues:

https://github.com/osgi/osgi.enroute/issues/63
https://github.com/osgi/osgi.enroute/issues/52
https://github.com/osgi/osgi.enroute/issues/47

I did not rebuild the site to check that the site builds normally, I'm hoping that these changes are simple enough.