### PR TITLE
Fix typos and make tutorial clearer for new users

### DIFF
--- a/_tutorial/015-Prerequisite.md
+++ b/_tutorial/015-Prerequisite.md
@@ -115,9 +115,11 @@ Since this part is rather sensitive to the operating system you're using, we hav
 
 ### Windows
 
-In the enRoute tutorials file paths are always indicated using the forward slash or solidus ('/') as is customary on *nix like systems. The reason is that bnd, since its files are portable, always uses relative addressing from the workspace and adopted the forward slash. For most developers mapping these paths to Windows should be straightforward.
+In the enRoute tutorials file paths are always indicated using the forward slash or solidus ('`/`') as is customary on *nix like systems. The reason is that bnd, since its files are portable, always uses relative addressing from the workspace and adopted the forward slash. For most developers mapping these paths to Windows should be straightforward.
 
-The only addressing outside the workspace is to the user's home directory, the user's home directory is indicated by a path that starts with a tilde and a slash ('~/'). This maps to the path indicated in Java's `user.home` System property.
+The only addressing outside the workspace is to the user's home directory, the user's home directory is indicated by a path that starts with a tilde and a slash ('`~/`'). This maps to the path indicated in Java's `user.home` System property.
+
+Some commands in this tutorial use line continuation symbols so that parameters can be differentiated and for ease of reading. The standard character used in this tutorial is the same one used by *nix like systems, the back slash ('`\`'). Be sure to remove these or replace them with the Windows equivalent symbol when running commands in your Windows command line shell (non-bash like shell).
 
 Make sure you have a good command line shell available. If you're familiar with one, keep it. If command lines are uncomfortable for you, you might want to use [Git for Windows][gitforwindows] which includes a bash like shell. Though virtually all work in OSGi enRoute can be done through an IDE, the tutorials use a *shell first* approach so that you can choose the IDE you want to use.
 

--- a/_tutorial/020-tutorial_qs.md
+++ b/_tutorial/020-tutorial_qs.md
@@ -18,12 +18,15 @@ We start by first downloading, building and running the enRoute `quick start` ex
 
 Download the [enroute examples](https://github.com/osgi/osgi.enroute) from GitHub and change directory into `examples/quickstart`.
 
+    ~ $ cd examples/quickstart
+{: .shell }
+
 ### Building the example
  
 Build the Application with the following command:
 
-    $ mvn verify
-{: .shell } 
+    ~/examples/quickstart $ mvn verify
+{: .shell }
 
 If you're using a Java version higher than 8 to run this tutorial then you'll need to set the appropriate `runee` in the `examples/quickstart/app/app.bndrun` and then resolve the application. For Java 9 use `JavaSE-9`, for Java 10 use `JavaSE-10` and for Java 11 use `JavaSE-11`. Once you have made this edit issue the command `mvn bnd-indexer:index bnd-indexer:index@test-index bnd-resolver:resolve` to generate the index, test index, and resolve the bndrun (you should be able to see the changes in the `runbundles` list afterwards). Once you've done this the first time then you can `mvn verify` to your heart's content.
 {: .note } 
@@ -32,7 +35,7 @@ If you're using a Java version higher than 8 to run this tutorial then you'll ne
 
 We now have a runnable artifact which can be started with the command:
 
-    $ java -jar app/target/app.jar
+    ~/examples/quickstart $ java -jar app/target/app.jar
 {: .shell }
 
 To test that the application is running visit the [quickstart](http://localhost:8080/quickstart/index.html) application URL for a friendly greeting,
@@ -52,9 +55,20 @@ It is assumed that you have the required [environment](015-Prerequisite.html#req
 
 ### Project Setup
 
-First issue the command to create the project template:
+First change into a new directory, since we are recreating the project:
 
-    $ mvn org.apache.maven.plugins:maven-archetype-plugin:3.0.1:generate -DarchetypeGroupId=org.osgi.enroute.archetype -DarchetypeArtifactId=project -DarchetypeVersion=7.0.0
+    ~/examples/quickstart $ cd ~
+{: .shell }
+
+Make sure the newly recreated project is not in the previous `examples/quickstart` directory structure, as it will also be named `quickstart`. Feel free to put it in the same parent directory as the downloaded `examples/quickstart` project or make a new directory outside the downloaded `examples/quickstart` project. For this tutorial, we put the newly created project in the `~` (AKA `/home/user`) directory. If you put your project in a different directory, be sure to replace the `~` with your directory path when it appears in shell snippets in the tutorial.
+{: .note }
+
+Then issue the command to create the project template:
+
+    ~ $ mvn org.apache.maven.plugins:maven-archetype-plugin:3.0.1:generate \
+        -DarchetypeGroupId=org.osgi.enroute.archetype \
+        -DarchetypeArtifactId=project \
+        -DarchetypeVersion=7.0.0
 {: .shell }
 
 We declare to use the version 3.0.1 of the `maven-archetype-plugin` because if the version is not fixed, Maven chooses the version and it does not work with e.g. version 2.4.
@@ -82,7 +96,7 @@ If you're using an IDE then this would be a good time to import the generated ma
 
 ### Implementing the Microservice
 
-Having created the project skeleton, edit `quickstart/impl/src/main/java/org/osgi/enroute/examples/quickstart/rest/ComponentImpl.java` 
+Having created the project skeleton, edit `~/quickstart/impl/src/main/java/org/osgi/enroute/examples/quickstart/rest/ComponentImpl.java`
 
 {% highlight shell-session %}
 package org.osgi.enroute.examples.quickstart.rest;
@@ -134,9 +148,9 @@ It's now time to build the implementation project.
 
  <div class="tab-content">
   <div markdown="1" role="tabpanel" class="tab-pane active" id="impl-build-cli">
-From the `quickstart/impl` project we now build the impl bundle.
+From the `~/quickstart/impl` project we now build the impl bundle.
 
-    $ mvn package
+    ~/quickstart/impl $ mvn package
 {: .shell }
       
 Here, we use the `package` goal to check that the code compiles and can be successfully packaged into a bundle. If we had tests or other post-packaging checks then we could have used the `verify` goal instead.
@@ -159,7 +173,7 @@ Enter package as the goal and click **Run**
 
 ### Resolving the Application
 
-Before generating the runtime dependency information used by the OSGi framework take a look at the file `quickstart\app\app.bndrun`
+Before generating the runtime dependency information used by the OSGi framework take a look at the file `~/quickstart/app/app.bndrun`
 
 {% highlight shell-session %}
 index: target/index.xml
@@ -188,7 +202,9 @@ The `runbundles` are automatically calculated for us via the process of [resolvi
   <div markdown="1" role="tabpanel" class="tab-pane active" id="resolve-cli">
 From the root of the `quickstart` project we now generate our indexes and resolve the application using the bnd-resolver-maven-plugin. As the `app` project references other projects in the same reactor we use the `-pl` flag to pick the `app` project and the `-am` flag to be sure all of our dependencies are packaged and up to date:
 
-    $ mvn -pl app -am  bnd-indexer:index bnd-indexer:index@test-index bnd-resolver:resolve package
+    ~/quickstart $ mvn -pl app -am  bnd-indexer:index \
+        bnd-indexer:index@test-index \
+        bnd-resolver:resolve package
 {: .shell }
 
 Note that the indexes are automatically regenerated every time you run through the package phase. If you want to generate the indexes for the `app` module without packaging everything then you can do so by issuing `mvn -pl app -am  bnd-indexer:index bnd-indexer:index@test-index`
@@ -238,7 +254,7 @@ Note that in this version of `quickstart` only the REST endpoint will be availab
   <div markdown="1" role="tabpanel" class="tab-pane active" id="run-cli">
 Now that the initial development is done we're ready to build and package the whole application by running the following command in the project root.
       
-    $ mvn package
+    ~/quickstart $ mvn package
 {: .shell }
 
 Your version of `quickstart` may now be started as described [above](020-tutorial_qs.html#running-the-example). It won't have a UI, but the REST endpoint will be available at [http://localhost:8080/rest/upper/lower](http://localhost:8080/rest/upper/lower).

--- a/_tutorial/022-tutorial_osgi_runtime.md
+++ b/_tutorial/022-tutorial_osgi_runtime.md
@@ -11,6 +11,9 @@ sponsor: OSGi™ Alliance
 
 In the `quickstart` tutorial we created and ran a simple OSGi Microservice. Before progressing to more sophisticated examples we'll first take a quick look at the OSGi runtime and the software DNA of your Microservices application.
 
+For this tutorial we put the project in the `~` (AKA `/home/user`) directory. If you put your project in a different directory, be sure to replace the `~` with  your directory path when it appears in shell snippets in the tutorial.
+{: .note }
+
 ## Creating the Debug Version of `quickstart`
 
 To gain access to the OSGi runtime we need to create a **debug** version of `quickstart`.
@@ -65,14 +68,14 @@ If you didn't run through the quickstart tutorial before this tutorial then you 
 
 Now resolve your bndrun files (always a good idea after making pom or bndrun changes) and re-build the `app` module of your `quickstart` application
 
-    $ cd app/
-    $ mvn bnd-resolver:resolve
-    $ mvn verify
+    ~/quickstart $ cd app/
+    ~/quickstart/app $ mvn bnd-resolver:resolve
+    ~/quickstart/app $ mvn verify
 {: .shell }
 
 and run the new debug version.
 
-    $ java -jar target/debug.jar
+    ~/quickstart/app $ java -jar target/debug.jar
 {: .shell }
 
 

--- a/_tutorial/030-tutorial_microservice.md
+++ b/_tutorial/030-tutorial_microservice.md
@@ -22,11 +22,17 @@ with each module having a POM that describes its dependencies.
 
 We start by creating the required project skeleton.
 
+For this tutorial we put the project in the `~` (AKA `/home/user`) directory. If you put your project in a different directory, be sure to replace the `~` with your directory path when it appears in shell snippets in the tutorial.
+{: .note }
+
 ## Creating the Project
 
 Using the [bare-project Archetype](../about/112-enRoute-Archetypes.html#the-project-archetype), in your project root directory create the **microservice** project:
 
-    $ mvn archetype:generate -DarchetypeGroupId=org.osgi.enroute.archetype -DarchetypeArtifactId=project-bare -DarchetypeVersion=7.0.0
+    ~ $ mvn archetype:generate \
+        -DarchetypeGroupId=org.osgi.enroute.archetype \
+        -DarchetypeArtifactId=project-bare \
+        -DarchetypeVersion=7.0.0
 {: .shell }
 
 with the following values:
@@ -53,7 +59,11 @@ We now create the required modules.
 
 Change directory into the newly created `microservice` project directory; then create the `api` module using the [api Archetype](../about/112-enRoute-Archetypes.html#the-api-archetype) as shown:
 
-    $ mvn archetype:generate -DarchetypeGroupId=org.osgi.enroute.archetype -DarchetypeArtifactId=api -DarchetypeVersion=7.0.0
+    ~ $ cd microservice
+    ~/microservice $ mvn archetype:generate \
+        -DarchetypeGroupId=org.osgi.enroute.archetype \
+        -DarchetypeArtifactId=api \
+        -DarchetypeVersion=7.0.0
 {: .shell }
 
 with the following values:
@@ -72,7 +82,7 @@ with the following values:
 
 Now create the following two files:
 
-`dao-api/src/main/java/org/osgi/enroute/examples/microservice/dao/PersonDao.java`
+`~/microservice/dao-api/src/main/java/org/osgi/enroute/examples/microservice/dao/PersonDao.java`
 <p>
   <a class="btn btn-primary" data-toggle="collapse" href="#PersonDao" aria-expanded="false" aria-controls="PersonDao">
     PersonDAO.java
@@ -87,7 +97,7 @@ Now create the following two files:
 </div>
 </div>
 
-`dao-api/src/main/java/org/osgi/enroute/examples/microservice/dao/AddressDao.java`
+`~/microservice/dao-api/src/main/java/org/osgi/enroute/examples/microservice/dao/AddressDao.java`
 <p>
   <a class="btn btn-primary" data-toggle="collapse" href="#AddressDao" aria-expanded="false" aria-controls="AddressDao">
     AddressDAO.java
@@ -107,7 +117,7 @@ Now create the following two files:
 `dao-api` has no dependencies.
 
 ### Visibility
-`dao-api` is an API package which is imported by `RestComponentImpl`, `PersonDaoImpl` & `AddressDaoImpl`; hence it must must be exported. This is indicated by the automatically generated file `dao-api/src/main/java/org/osgi/enroute/examples/microservice/dao/package-info.java`:
+`dao-api` is an API package which is imported by `RestComponentImpl`, `PersonDaoImpl` & `AddressDaoImpl`; hence it must must be exported. This is indicated by the automatically generated file `~/microservice/dao-api/src/main/java/org/osgi/enroute/examples/microservice/dao/package-info.java`:
 <p>
   <a class="btn btn-primary" data-toggle="collapse" href="#package-info-dao" aria-expanded="false" aria-controls="package-info-dao">
     package-info.java
@@ -130,7 +140,7 @@ Data transfer between the components is achieved via the use of [Data Transfer O
 
 To achieve this create the following two files:
 
-`dao-api/src/main/java/org/osgi/enroute/examples/microservice/dao/dto/PersonDTO.java`
+`~/microservice/dao-api/src/main/java/org/osgi/enroute/examples/microservice/dao/dto/PersonDTO.java`
 <p>
   <a class="btn btn-primary" data-toggle="collapse" href="#PersonDTO" aria-expanded="false" aria-controls="PersonDTO">
     PersonDTO.java
@@ -145,7 +155,7 @@ To achieve this create the following two files:
 </div>
 </div>
 
-`dao-api/src/main/java/org/osgi/enroute/examples/microservice/dao/dto/AddressDTO.java`
+`~/microservice/dao-api/src/main/java/org/osgi/enroute/examples/microservice/dao/dto/AddressDTO.java`
 <p>
   <a class="btn btn-primary" data-toggle="collapse" href="#AddressDTO" aria-expanded="false" aria-controls="AddressDTO">
    AddressDTO.java
@@ -162,7 +172,7 @@ To achieve this create the following two files:
 
 and again, we advertise this Capability by creating the following `package-info.java` file:
 
-`dao-api/src/main/java/org/osgi/enroute/examples/microservice/dao/dto/package-info.java`
+`~/microservice/dao-api/src/main/java/org/osgi/enroute/examples/microservice/dao/dto/package-info.java`
 <p>
   <a class="btn btn-primary" data-toggle="collapse" href="#package-info-dto" aria-expanded="false" aria-controls="package-info-dto">
     package-info.java
@@ -180,9 +190,12 @@ and again, we advertise this Capability by creating the following `package-info.
 
 ## The DAO Implementation
 
-In the `microservice` project director now create the `impl` module using the [ds-component Archetype](../about/112-enRoute-Archetypes.html#the-ds-component-archetype):
+Now, in the `microservice` project directory, create the `impl` module using the [ds-component Archetype](../about/112-enRoute-Archetypes.html#the-ds-component-archetype):
 
-    $ mvn archetype:generate -DarchetypeGroupId=org.osgi.enroute.archetype -DarchetypeArtifactId=ds-component -DarchetypeVersion=7.0.0
+    ~/microservice $ mvn archetype:generate \
+        -DarchetypeGroupId=org.osgi.enroute.archetype \
+        -DarchetypeArtifactId=ds-component \
+        -DarchetypeVersion=7.0.0
 {: .shell }
 
 with the following values:
@@ -201,7 +214,7 @@ with the following values:
 
 Now create the following four files:
 
-`dao-impl/src/main/java/org/osgi/enroute/examples/microservice/dao/impl/PersonTable.java`
+`~/microservice/dao-impl/src/main/java/org/osgi/enroute/examples/microservice/dao/impl/PersonTable.java`
 <p>
   <a class="btn btn-primary" data-toggle="collapse" href="#PersonTable" aria-expanded="false" aria-controls="PersonTable">
     PersonTable.java
@@ -218,7 +231,7 @@ Now create the following four files:
 </div>
 
 
-`dao-impl/src/main/java/org/osgi/enroute/examples/microservice/dao/impl/PersonDaoImpl.java`
+`~/microservice/dao-impl/src/main/java/org/osgi/enroute/examples/microservice/dao/impl/PersonDaoImpl.java`
 <p>
   <a class="btn btn-primary" data-toggle="collapse" href="#PersonDaoImpl" aria-expanded="false" aria-controls="PersonDaoImpl">
     PersonDaoImpl.java
@@ -235,7 +248,7 @@ Now create the following four files:
 </div>
 
 
-`dao-impl/src/main/java/org/osgi/enroute/examples/microservice/dao/impl/AddressTable.java`
+`~/microservice/dao-impl/src/main/java/org/osgi/enroute/examples/microservice/dao/impl/AddressTable.java`
 <p>
   <a class="btn btn-primary" data-toggle="collapse" href="#AddressTable" aria-expanded="false" aria-controls="AddressTable">
     AddressTable.java
@@ -251,7 +264,7 @@ Now create the following four files:
 </div>
 
 
-`dao-impl/src/main/java/org/osgi/enroute/examples/microservice/dao/impl/AddressDaoImpl.java`
+`~/microservice/dao-impl/src/main/java/org/osgi/enroute/examples/microservice/dao/impl/AddressDaoImpl.java`
 <p>
   <a class="btn btn-primary" data-toggle="collapse" href="#AddressDaoImpl" aria-expanded="false" aria-controls="AddressDaoImpl">
     AddressDaoImpl.java
@@ -291,9 +304,12 @@ Implementations should **NOT** be shared; hence no `package-info.java` file.
 
 ## The REST Service
 
-In the `microservice` project director now create the `rest-component` module using the [rest-component Archetype](../about/112-enRoute-Archetypes.html#the-rest-component-archetype):
+In the `microservice` project directory now create the `rest-component` module using the [rest-component Archetype](../about/112-enRoute-Archetypes.html#the-rest-component-archetype):
 
-    $ mvn archetype:generate -DarchetypeGroupId=org.osgi.enroute.archetype -DarchetypeArtifactId=rest-component -DarchetypeVersion=7.0.0
+    ~/microservice $ mvn archetype:generate \
+        -DarchetypeGroupId=org.osgi.enroute.archetype \
+        -DarchetypeArtifactId=rest-component \
+        -DarchetypeVersion=7.0.0
 {: .shell }
 
 with the following values:
@@ -312,7 +328,7 @@ with the following values:
 
 Now create the following two files:
 
-`rest-service/src/main/java/org/osgi/enroute/examples/microservice/rest/RestComponentImpl.java`
+`~/microservice/rest-service/src/main/java/org/osgi/enroute/examples/microservice/rest/RestComponentImpl.java`
 <p>
   <a class="btn btn-primary" data-toggle="collapse" href="#RestComponentImpl" aria-expanded="false" aria-controls="RestComponentImpl">
     RestComponentImpl.java
@@ -329,7 +345,7 @@ Now create the following two files:
 </div>
 
 
-`rest-service/src/main/java/org/osgi/enroute/examples/microservice/rest/JsonpConvertingPlugin.java`
+`~/microservice/rest-service/src/main/java/org/osgi/enroute/examples/microservice/rest/JsonpConvertingPlugin.java`
 <p>
   <a class="btn btn-primary" data-toggle="collapse" href="#JsonpConvertingPlugin" aria-expanded="false" aria-controls="JsonpConvertingPlugin">
    JsonpConvertingPlugin.java
@@ -346,9 +362,9 @@ Now create the following two files:
 </div>
 
 
-Create the directory `rest-service/src/main/resources/static/main/html` and added the following file:
+Create the directory `~/microservice/rest-service/src/main/resources/static/main/html` and added the following file:
 
-`rest-service/src/main/resources/static/main/html/person.html`
+`~/microservice/rest-service/src/main/resources/static/main/html/person.html`
 <p>
   <a class="btn btn-primary" data-toggle="collapse" href="#person" aria-expanded="false" aria-controls="person">
     person.html
@@ -364,9 +380,9 @@ Create the directory `rest-service/src/main/resources/static/main/html` and adde
 </div>
 </div>
 
-And also the `rest-service/src/main/resources/static/css` directory for the following `style.css` file
+And also the `~/microservice/rest-service/src/main/resources/static/css` directory for the following `style.css` file
 
-`rest-service/src/main/resources/static/css/style.css`
+`~/microservice/rest-service/src/main/resources/static/css/style.css`
 <p>
   <a class="btn btn-primary" data-toggle="collapse" href="#style" aria-expanded="false" aria-controls="style">
    style.css
@@ -382,9 +398,9 @@ And also the `rest-service/src/main/resources/static/css` directory for the foll
 </div>
 </div>
 
-Finally, place the following `index.html` file in directory `rest-service/src/main/resources/static`
+Finally, place the following `index.html` file in directory `~/microservice/rest-service/src/main/resources/static`
 
-`rest-service/src/main/resources/static/index.html`
+`~/microservice/rest-service/src/main/resources/static/index.html`
 <p>
   <a class="btn btn-primary" data-toggle="collapse" href="#index" aria-expanded="false" aria-controls="index">
     index.html
@@ -400,13 +416,13 @@ Finally, place the following `index.html` file in directory `rest-service/src/ma
 </div>
 </div>
 
-and create the directory `rest-service/src/main/resources/static/main/img` into which save the following icon with the name `enroute-logo-64.png`.
+and create the directory `~/microservice/rest-service/src/main/resources/static/main/img` into which save the following icon with the name `enroute-logo-64.png`.
 
 ![enRoute logo](img/enroute-logo-64.png)
 
 ### Dependencies
 
-As the `rest-service` module has dependencies on the `dao-api` and `json-api` these dependencies are added to the `<dependencies>` section in `rest-service/pom.xml`. A `JSON-P` implementation dependency is also included so that the `rest-service` can be unit tested.
+As the `rest-service` module has dependencies on the `dao-api` and `json-api` these dependencies are added to the `<dependencies>` section in `~/microservice/rest-service/pom.xml`. A `JSON-P` implementation dependency is also included so that the `rest-service` can be unit tested.
 
 {% highlight xml %}
 <dependency>
@@ -438,7 +454,10 @@ We now pull these Modules together to create the Composite Application.
 
 In the `microservice` project directory create the `application` module using the [application Archetype](../about/112-enRoute-Archetypes.html#the-application-archetype):
 
-    $ mvn archetype:generate -DarchetypeGroupId=org.osgi.enroute.archetype -DarchetypeArtifactId=application -DarchetypeVersion=7.0.0
+    ~/microservice $ mvn archetype:generate \
+        -DarchetypeGroupId=org.osgi.enroute.archetype \
+        -DarchetypeArtifactId=application \
+        -DarchetypeVersion=7.0.0
 {: .shell }
 
 with the following values:
@@ -470,7 +489,7 @@ Our Microservice is composed of the following elements:
 * An implementation of JSON-P (org.apache.johnzon.core)
 * An in memory database (H2).
 
-These dependencies are expressed as runtime Requirements in the `rest-app/rest-app.bndrun` file:
+These dependencies are expressed as runtime Requirements in the `~/microservice/rest-app/rest-app.bndrun` file:
 
 {% highlight shell-session %}
 index: target/index.xml
@@ -491,7 +510,7 @@ index: target/index.xml
 
 ### Dependencies
 
-By adding the following dependencies inside the `<dependencies>` section of the file `rest-app/pom.xml`, we added the necessary Capabilities to the `rest-app`'s repository.
+By adding the following dependencies inside the `<dependencies>` section of the file `~/microservice/rest-app/pom.xml`, we add the necessary Capabilities to the `rest-app`'s repository.
 
 {% highlight xml %}
 <dependency>
@@ -516,7 +535,7 @@ By adding the following dependencies inside the `<dependencies>` section of the 
 
 Finally, our Microservice will be configured using the new R7 Configurator mechanism.
 
-The [application Archetype](../about/112-enRoute-Archetypes.html##the-application-archetype) enables this via `rest-app/src/main/java/config/package-info.java`.
+The [application Archetype](../about/112-enRoute-Archetypes.html##the-application-archetype) enables this via `~/microservice/rest-app/src/main/java/config/package-info.java`.
 <p>
   <a class="btn btn-primary" data-toggle="collapse" href="#package-info-config" aria-expanded="false" aria-controls="package-info-config">
     package-info.java
@@ -531,7 +550,7 @@ The [application Archetype](../about/112-enRoute-Archetypes.html##the-applicatio
 </div>
 </div>
 
-All that is required is to pass in the appropriate configuration by overwrite the contents of `rest-app/src/main/resources/OSGI-INF/configurator/configuration.json` with the following:
+To pass in the appropriate configuration, overwrite the contents of `~/microservice/rest-app/src/main/resources/OSGI-INF/configurator/configuration.json` with the following:
 
  <p>
   <a class="btn btn-primary" data-toggle="collapse" href="#configuration" aria-expanded="false" aria-controls="configuration">
@@ -552,12 +571,15 @@ All that is required is to pass in the appropriate configuration by overwrite th
 
 Check the modules that make up your application build cleanly from the top level project directory
 
-    mvn -pl !rest-app verify
+    ~/microservice $ mvn -pl !rest-app verify
 {: .shell }
+
+**Note** - If you are a linux/unix/*nix user, you might need to escape the exclamation point in the above command.
+{: .note }
 
 Now build the rest-app bundle using package command.
 
-    mvn -pl rest-app package
+    ~/microservice $ mvn -pl rest-app package
 {: .shell }
 
 **Note** - if this build fails then check your code and pom dependencies and try again.
@@ -565,7 +587,8 @@ Now build the rest-app bundle using package command.
 
 We now generate the required OSGi indexes from the project dependencies, and resolve our application.
 
-    mvn -pl rest-app -am bnd-indexer:index bnd-indexer:index@test-index bnd-resolver:resolve
+    ~/microservice $ mvn -pl rest-app -am bnd-indexer:index \
+        bnd-indexer:index@test-index bnd-resolver:resolve
 {: .shell }
 
 **Note** Don't do a clean before running this step, it's building the indexes and resolution from the bundles you made in the previous step. Also, you don't need to run this step every time, just if your dependency graph needs to be recalculated.
@@ -573,10 +596,10 @@ We now generate the required OSGi indexes from the project dependencies, and res
 
 And finally generate the runnable jar from the top level project directory.
 
-    mvn verify
+    ~/microservice $ mvn verify
 {: .shell }
 
-Re-inspecting `rest-app/rest-app.bndrun` we can see that this now explicitly references the acceptable version range for each required OSGi bundle. At runtime the OSGi framework resolves these _requirements_ against the _capabilities_ in the specified target repository: i.e. `target/index.xml`.  
+Re-inspecting `~/microservice/rest-app/rest-app.bndrun` we can see that this now explicitly references the acceptable version range for each required OSGi bundle. At runtime the OSGi framework resolves these _requirements_ against the _capabilities_ in the specified target repository: i.e. `target/index.xml`.
 
 {% highlight shell-session %}
 {% include osgi.enroute/examples/microservice/rest-app/rest-app.bndrun %}
@@ -586,7 +609,7 @@ Re-inspecting `rest-app/rest-app.bndrun` we can see that this now explicitly ref
 
 To dynamically assemble and run the resultant REST Microservice simply change back to the top level project directory and type the command:
 
-    java -jar rest-app/target/rest-app.jar
+    ~/microservice $ java -jar rest-app/target/rest-app.jar
 {: .shell }
 
 The REST service can be seen by pointing a browser to [http://localhost:8080/microservice/index.html](http://localhost:8080/microservice/index.html)

--- a/_tutorial/032-tutorial_microservice-jpa.md
+++ b/_tutorial/032-tutorial_microservice-jpa.md
@@ -10,6 +10,9 @@ sponsor: OSGi™ Alliance
 
 The previous Microservices example which uses `jdbc` provides the start-point for this tutorial.
 
+For this tutorial we put the project in the `~` (AKA `/home/user`) directory. If you put your project in a different directory, be sure to replace the `~` with your directory path when it appears in shell snippets in the tutorial.
+{: .note }
+
 In this tutorial we'll modify the Microservice to switch the data-layer from a JDBC to a JPA. Because of the de-coupling provided by the [DTOs](../FAQ/420-dtos.html)'s, all we need do is re-implement `dao-impl` and the composite application.
 
 **Note** - because of the use of DTOs, OSGi allows us, via setting one property, to separate the data-layer and REST Services layers of our Microservice across a local IP local network using secure low latency [Remote Services](https://osgi.org/specification/osgi.cmpn/7.0.0/service.remoteservices.html).
@@ -19,7 +22,10 @@ In this tutorial we'll modify the Microservice to switch the data-layer from a J
 
 In the `microservice` project root directory, create the `jpa` project.
 
-      mvn archetype:generate -DarchetypeGroupId=org.osgi.enroute.archetype -DarchetypeArtifactId=ds-component -DarchetypeVersion=7.0.0
+      ~/microservice $ mvn archetype:generate \
+          -DarchetypeGroupId=org.osgi.enroute.archetype \
+          -DarchetypeArtifactId=ds-component \
+          -DarchetypeVersion=7.0.0
 {: .shell }
 
 input the following values:
@@ -37,7 +43,7 @@ input the following values:
 {: .shell }
 
 
-Add the following file `dao-impl-jpa/src/main/java/org/osgi/enroute/examples/microservice/dao/impl/jpa/AddressDaoImpl.java`
+Add the following file `~/microservice/dao-impl-jpa/src/main/java/org/osgi/enroute/examples/microservice/dao/impl/jpa/AddressDaoImpl.java`
 <p>
   <a class="btn btn-primary" data-toggle="collapse" href="#AddressDaoImpl" aria-expanded="false" aria-controls="AddressDaoImpl">
     AddressDaoImpl.java
@@ -52,7 +58,7 @@ Add the following file `dao-impl-jpa/src/main/java/org/osgi/enroute/examples/mic
   </div>
 </div>
 
-Add the following file `dao-impl-jpa/src/main/java/org/osgi/enroute/examples/microservice/dao/impl/jpa/PersonDaoImpl.java`
+Add the following file `~/microservice/dao-impl-jpa/src/main/java/org/osgi/enroute/examples/microservice/dao/impl/jpa/PersonDaoImpl.java`
 <p>
   <a class="btn btn-primary" data-toggle="collapse" href="#PersonDaoImpl" aria-expanded="false" aria-controls="PersonDaoImpl">
     PersonDaoImpl.java
@@ -87,9 +93,9 @@ To address a hibernate bug we need to add the following `dao-impl-jpa/bnd.bnd`fi
 
 ### The JPA Entities
 
-Create the directory `dao-impl-jpa/src/main/java/org/osgi/enroute/examples/microservice/dao/impl/jpa/entities`
+Create the directory `~/microservice/dao-impl-jpa/src/main/java/org/osgi/enroute/examples/microservice/dao/impl/jpa/entities`
 
-Add the following file `dao-impl-jpa/src/main/java/org/osgi/enroute/examples/microservice/dao/impl/jpa/entities/AddressEntity.java`
+Add the following file `~/microservice/dao-impl-jpa/src/main/java/org/osgi/enroute/examples/microservice/dao/impl/jpa/entities/AddressEntity.java`
 <p>
   <a class="btn btn-primary" data-toggle="collapse" href="#AddressEntity" aria-expanded="false" aria-controls="AddressEntity">
     AddressEntity.java
@@ -105,7 +111,7 @@ Add the following file `dao-impl-jpa/src/main/java/org/osgi/enroute/examples/mic
 </div>
 
 
-Add the following file `dao-impl-jpa/src/main/java/org/osgi/enroute/examples/microservice/dao/impl/jpa/entities/PersonEntity.java`:
+Add the following file `~/microservice/dao-impl-jpa/src/main/java/org/osgi/enroute/examples/microservice/dao/impl/jpa/entities/PersonEntity.java`:
 <p>
   <a class="btn btn-primary" data-toggle="collapse" href="#PersonEntity" aria-expanded="false" aria-controls="PersonEntity">
     PersonEntity.java
@@ -120,7 +126,7 @@ Add the following file `dao-impl-jpa/src/main/java/org/osgi/enroute/examples/mic
   </div>
 </div>
 
-The resultant persistence bundle has a Requirement for a JPA service extender. Hence we add the following file `dao-impl-jpa/src/main/java/org/osgi/enroute/examples/microservice/dao/impl/jpa/entities/package-info.java`:
+The resultant persistence bundle has a Requirement for a JPA service extender. Hence we add the following file `~/microservice/dao-impl-jpa/src/main/java/org/osgi/enroute/examples/microservice/dao/impl/jpa/entities/package-info.java`:
 <p>
   <a class="btn btn-primary" data-toggle="collapse" href="#package-info" aria-expanded="false" aria-controls="package-info">
     package-info.java
@@ -140,7 +146,7 @@ The resultant persistence bundle has a Requirement for a JPA service extender. H
 
 Create the following JPA resources:
 
-`dao-impl-jpa/src/main/resources/META-INF/persistence.xml`
+`~/microservice/dao-impl-jpa/src/main/resources/META-INF/persistence.xml`
 <p>
   <a class="btn btn-primary" data-toggle="collapse" href="#persistence" aria-expanded="false" aria-controls="persistence">
     persistence.xml
@@ -156,7 +162,7 @@ Create the following JPA resources:
 </div>
 
 
-`dao-impl-jpa/src/main/resources/META-INF/tables.sql`
+`~/microservice/dao-impl-jpa/src/main/resources/META-INF/tables.sql`
 <p>
   <a class="btn btn-primary" data-toggle="collapse" href="#tables" aria-expanded="false" aria-controls="tables">
    tables.sql
@@ -174,7 +180,7 @@ Create the following JPA resources:
 
 ### Dependencies
 
-Edit `dao-impl-jpa/pom.xml` to add the following dependencies in the `<dependencies>` section:
+Edit `~/microservice/dao-impl-jpa/pom.xml` to add the following dependencies in the `<dependencies>` section:
 
 {% highlight xml %}
     <dependency>
@@ -194,7 +200,10 @@ Edit `dao-impl-jpa/pom.xml` to add the following dependencies in the `<dependenc
 
 Create the alternative JPA application project.
 
-     $ mvn archetype:generate -DarchetypeGroupId=org.osgi.enroute.archetype -DarchetypeArtifactId=application -DarchetypeVersion=7.0.0
+     ~/microservice $ mvn archetype:generate \
+        -DarchetypeGroupId=org.osgi.enroute.archetype \
+        -DarchetypeArtifactId=application \
+        -DarchetypeVersion=7.0.0
 {: .shell }
 
     Define value for property 'groupId': org.osgi.enroute.examples.microservice
@@ -210,7 +219,7 @@ Create the alternative JPA application project.
     artifactId: rest-app-jpa
     version: 0.0.1-SNAPSHOT
     package: org.osgi.enroute.examples.microservice
-    impl-artifactId: dao-impl-jpa
+    impl-artifactId: rest-service
     impl-groupId: org.osgi.enroute.examples.microservice
     impl-version: 0.0.1-SNAPSHOT
     app-target-java-version: 8
@@ -220,7 +229,7 @@ Create the alternative JPA application project.
 
 ### Define Runtime Entity
 
-Add the following sections to `rest-app-jpa/rest-app-jpa.bndrun`:
+Add the following sections to `~/microservice/rest-app-jpa/rest-app-jpa.bndrun`:
 
 {% highlight shell-session %}
 -resolve.effective: active
@@ -241,7 +250,7 @@ The `-runpath` needs to be specified for Java 8 because the Java 8 JRE has a spl
 The `-runsystempackages` is required because Hibernate has versioned imports for JTA, and its dependency dom4j has versioned imports for the STAX API. When using Java 8 both of these should come from the JRE. When using Java 9 and above the APIs can be provided by bundles in the OSGi framework.
 {: .note }
 
-Edit the `-runrequires`  section in `rest-app-jpa/res-app-jpa.bndrun` to include the composite application's requirements:
+Edit the `-runrequires`  section in `~/microservice/rest-app-jpa/res-app-jpa.bndrun` to include the composite application's requirements:
 
 {% highlight shell-session %}
 -runrequires: \
@@ -253,7 +262,7 @@ Edit the `-runrequires`  section in `rest-app-jpa/res-app-jpa.bndrun` to include
 
 ### Dependencies
 
-Edit `rest-app-jpa/pom.xml` adding the following dependencies in the `<dependencies>` section:
+Edit `~/microservice/rest-app-jpa/pom.xml` adding the following dependencies in the `<dependencies>` section:
 
 {% highlight xml %}
     <dependency>
@@ -292,7 +301,7 @@ Edit `rest-app-jpa/pom.xml` adding the following dependencies in the `<dependenc
 
 ### Runtime Configuration
 
-Add the following configuration file `rest-app-jpa/src/main/resources/OSGI-INF/configurator/configuration.json`:
+Add the following configuration file `~/microservice/rest-app-jpa/src/main/resources/OSGI-INF/configurator/configuration.json`:
 <p>
   <a class="btn btn-primary" data-toggle="collapse" href="#configuration" aria-expanded="false" aria-controls="configuration">
    configuration.json
@@ -312,19 +321,23 @@ Add the following configuration file `rest-app-jpa/src/main/resources/OSGI-INF/c
 
 We build and run the examples as in the previous JDBC Microservices example.
 
-    mvn install
+    ~/microservice $ mvn install
 {: .shell }
 
 **Note** - if `rest-app-jpa` fails, run the following resolve command and then re-run `mvn install`
 {: .note }
 
-    mvn bnd-resolver:resolve
+    ~/microservice $ mvn bnd-resolver:resolve
 {: .shell }
 
-    mvn package
+Once the `mvn install` command succeeds, run the following command to build the jar.
+
+    ~/microservice $ mvn package
 {: .shell }
 
-    java -jar rest-app-jpa/target/rest-app.jar
+Run the newly created jar.
+
+    ~/microservice $ java -jar rest-app-jpa/target/rest-app-jpa.jar
 {: .shell }
 
 The REST Service can be seen by pointing a browser to [http://localhost:8080/microservice/index.html](http://localhost:8080/microservice/index.html)


### PR DESCRIPTION
- Fix typos and reword some phrases  (#198, #196)
- Add paths to commands for clarity (#195)
- Add note about escaping ! char in tutorial (#197)
- Add note in prerequisites about *nix-like line continuation symbols ('`\`')